### PR TITLE
Fixes for unsigned PSBT

### DIFF
--- a/apps/coordinator/src/components/ScriptExplorer/DirectSignatureImporter.jsx
+++ b/apps/coordinator/src/components/ScriptExplorer/DirectSignatureImporter.jsx
@@ -45,6 +45,7 @@ class DirectSignatureImporter extends React.Component {
       outputs,
       walletConfig,
       extendedPublicKeyImporter,
+      unsignedPSBT,
     } = this.props;
     const keystore = signatureImporter.method;
     const bip32Paths = inputs.map((input) => {
@@ -64,6 +65,7 @@ class DirectSignatureImporter extends React.Component {
       bip32Paths,
       walletConfig,
       policyHmac,
+      psbt: unsignedPSBT,
       returnSignatureArray: true,
     });
   };
@@ -295,6 +297,7 @@ DirectSignatureImporter.propTypes = {
     method: PropTypes.string,
   }).isRequired,
   signatureImporters: PropTypes.shape({}).isRequired,
+  unsignedPSBT: PropTypes.string.isRequired,
   walletConfig: PropTypes.shape(walletConfigPropType).isRequired,
   validateAndSetBIP32Path: PropTypes.func.isRequired,
   validateAndSetSignature: PropTypes.func.isRequired,

--- a/apps/coordinator/src/components/ScriptExplorer/SignatureImporter.jsx
+++ b/apps/coordinator/src/components/ScriptExplorer/SignatureImporter.jsx
@@ -145,7 +145,7 @@ class SignatureImporter extends React.Component {
       fee,
       isWallet,
       extendedPublicKeyImporter,
-      unsignedPsbt,
+      unsignedPSBT,
       extendedPublicKeys,
       requiredSigners,
       addressType,
@@ -173,6 +173,7 @@ class SignatureImporter extends React.Component {
           validateAndSetSignature={this.validateAndSetSignature}
           enableChangeMethod={this.enableChangeMethod}
           disableChangeMethod={this.disableChangeMethod}
+          unsignedPSBT={unsignedPSBT}
           walletConfig={{
             addressType,
             network,
@@ -194,7 +195,7 @@ class SignatureImporter extends React.Component {
           outputs={outputs}
           inputsTotalSats={inputsTotalSats}
           fee={fee}
-          unsignedPsbt={unsignedPsbt}
+          unsignedPSBT={unsignedPSBT}
           extendedPublicKeyImporter={extendedPublicKeyImporter}
           validateAndSetBIP32Path={this.validateAndSetBIP32Path}
           resetBIP32Path={this.resetBIP32Path}
@@ -621,7 +622,7 @@ SignatureImporter.propTypes = {
   txid: PropTypes.string.isRequired,
   unsignedTransaction: PropTypes.shape({}).isRequired,
   setSigningKey: PropTypes.func.isRequired,
-  unsignedPsbt: PropTypes.string,
+  unsignedPSBT: PropTypes.string,
   walletName: PropTypes.string.isRequired,
   walletUuid: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
@@ -630,7 +631,7 @@ SignatureImporter.propTypes = {
 
 SignatureImporter.defaultProps = {
   extendedPublicKeyImporter: {},
-  unsignedPsbt: "",
+  unsignedPSBT: "",
 };
 
 function mapStateToProps(state, ownProps) {

--- a/apps/coordinator/src/reducers/transactionReducer.js
+++ b/apps/coordinator/src/reducers/transactionReducer.js
@@ -283,6 +283,7 @@ function finalizeOutputs(state, action) {
   let unsignedTransaction;
   // First try to build the transaction via PSBT, if that fails (e.g. an input doesn't know about its braid),
   // then try to build it using the old TransactionBuilder plumbing.
+  let unsignedPSBT = "";
   try {
     const args = {
       network: state.network,
@@ -293,6 +294,7 @@ function finalizeOutputs(state, action) {
     unsignedTransaction = Transaction.fromHex(
       psbt.data.globalMap.unsignedTx.toBuffer().toString("hex"),
     );
+    unsignedPSBT = psbt.toBase64();
   } catch (e) {
     // probably has an input that isn't braid aware.
     // NOTE: This won't work for txs with taproot outputs
@@ -304,7 +306,7 @@ function finalizeOutputs(state, action) {
   }
   return {
     ...state,
-    ...{ finalizedOutputs: action.value, unsignedTransaction },
+    ...{ finalizedOutputs: action.value, unsignedTransaction, unsignedPSBT },
   };
 }
 

--- a/packages/caravan-wallets/src/coldcard.ts
+++ b/packages/caravan-wallets/src/coldcard.ts
@@ -431,7 +431,6 @@ export class ColdcardSignMultisigTransaction extends ColdcardInteraction {
           inputs: inputs.map(convertLegacyInput),
           outputs: outputs.map(convertLegacyOutput),
         });
-        console.log("HELLLO??", this.psbt);
       } catch (e) {
         console.error("Error building PSBT", e);
         throw new Error(


### PR DESCRIPTION
Couple issues here, both kind of silly. First was inconsistent typing (unsignedPsbt vs unsignedPSBT, I prefer the former but consistency is obviously most important), TS fixes this. The second was just that we were not setting the psbt once the tx is finalized and ready for signing. This would be a nice cleanup for using the keystore interactions as we can avoid sending the more complex arguments if we just have the psbt (for the ones that support that api which all should now). 

You can see here where the store is updated now.
<img width="1512" alt="Screenshot 2024-09-02 at 9 51 42 PM" src="https://github.com/user-attachments/assets/c90c332f-7ce9-4a57-aff9-837d100a6a0a">
